### PR TITLE
onChangeEnd event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ function App() {
 | Prop | Default | Type | Description |
 | :--- | :---: | :---: | :--- |
 | items | `Array` | `Array<ItemType>` | Data that will be rendered as options |
-| onChange | `-` | `({index, item}) => void` | Function will send `item` and `index` option selected |
+| onChange | `-` | `({index, item}) => void` | Function will be called during scrolling |
+| onChangeEnd | `-` | `({index, item}) => void` | Function will be called after scroll end |
 | initialSelectedIndex | `-` | `number` | Inital index will be selected |
 | height | `200` | `number` | Style height for container |
 | width | `150` | `number` | Style width for container |

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
               {props.label}
             </Text>
           )}
+          onChangeEnd={({ item }) => console.log('Province.onChangeEnd', item)}
         />
 
         <WheelPickerExpo
@@ -40,6 +41,7 @@ export default function App() {
           initialSelectedIndex={3}
           items={CITIES.map((name) => ({ label: name, value: '' }))}
           onChange={({ item }) => setCity(item.label)}
+          onChangeEnd={({ item }) => console.log('City.onChangeEnd', item)}
         />
       </View>
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -143,6 +143,13 @@ class ViuPicker extends PureComponent<IViuPickerProps, IViuPickerState> {
             index,
           })}
           snapToInterval={itemHeight}
+          onMomentumScrollEnd={() => {
+            const { items, onChangeEnd } = this.props;
+            if (onChangeEnd) {
+              const { selectedIndex } = this.state;
+              onChangeEnd({ index: selectedIndex, item: items[selectedIndex] });
+            }
+          }}
         />
         <View
           style={[

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,6 +70,14 @@ class ViuPicker extends PureComponent<IViuPickerProps, IViuPickerState> {
     }
   };
 
+  handleOnChangeEnd = () => {
+    const { items, onChangeEnd } = this.props;
+    if (onChangeEnd) {
+      const { selectedIndex } = this.state;
+      onChangeEnd({ index: selectedIndex, item: items[selectedIndex] });
+    }
+  };
+
   setData() {
     let { itemHeight, listHeight } = this.state;
     const { items, height } = this.props;
@@ -143,13 +151,8 @@ class ViuPicker extends PureComponent<IViuPickerProps, IViuPickerState> {
             index,
           })}
           snapToInterval={itemHeight}
-          onMomentumScrollEnd={() => {
-            const { items, onChangeEnd } = this.props;
-            if (onChangeEnd) {
-              const { selectedIndex } = this.state;
-              onChangeEnd({ index: selectedIndex, item: items[selectedIndex] });
-            }
-          }}
+          onMomentumScrollEnd={this.handleOnChangeEnd}
+          onScrollToTop={this.handleOnChangeEnd}
         />
         <View
           style={[

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,8 @@ export type RenderItemProps = {
 
 export interface IViuPickerProps {
   items: ItemType[];
-  onChange: (item: { index: number; item: ItemType }) => void;
+  onChange?: (item: { index: number; item: ItemType }) => void;
+  onChangeEnd?: (item: { index: number; item: ItemType }) => void;
   initialSelectedIndex?: number;
   height?: number;
   width?: any;


### PR DESCRIPTION
https://github.com/adityamr15/react-native-wheel-picker-expo/issues/5

> About onScrollEndDrag, I noticed that it doesn't work as expected because it fires the moment the user releases their finger.

I was able to implement this as expected as well using [onMomentumScrollEnd](https://reactnative.dev/docs/scrollview#onmomentumscrollend).

In addition to user scrolling, I have confirmed that it also fires when...

* When I tap the status bar and scroll to the top.
* When call scrollTo(), scrollToEnd(), scrollToIndex(), scrollToItem(), scrollToOffset()

